### PR TITLE
Fixed a bug that caused the dropdown toggle method so it appeared like the dropdown is being closed and opened at the same time

### DIFF
--- a/MultiSelectPackage/Components/MultiSelect.razor
+++ b/MultiSelectPackage/Components/MultiSelect.razor
@@ -10,7 +10,7 @@
 	}
 
 	<!-- Dropdown with Multiple Selections -->
-	<div class="dropdown-list">
+	<div class="dropdown-list" @onclick:stopPropagation="true">
 		@if (FilteredItemList != null && FilteredItemList.Any())
 		{
 			@foreach (var item in FilteredItemList)

--- a/MultiSelectPackage/Components/MultiSelect.razor.cs
+++ b/MultiSelectPackage/Components/MultiSelect.razor.cs
@@ -44,6 +44,8 @@ namespace MultiSelectPackage.Components
 
 		#endregion
 
+		#region Methods
+
 		protected override async Task OnParametersSetAsync()
 		{
 			if (Items != null && Items.Any())
@@ -187,5 +189,7 @@ namespace MultiSelectPackage.Components
 				return $"{(string.IsNullOrWhiteSpace(CustomStyle) ? string.Empty : CustomStyle)};";
 			}
 		}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
Fixed a bug that caused the dropdown toggle method so it appeared like the dropdown is being closed and opened at the same time

Enhance MultiSelect component interaction and structure

- Added `@onclick:stopPropagation="true"` to prevent event propagation in the dropdown list.
- Introduced a new `Methods` region in `MultiSelect.razor.cs` with an overridden `OnParametersSetAsync` method to improve parameter handling.
- Added a closing `#endregion` for better code organization and readability.

#### PR Classification
Enhancement of user interaction and parameter handling in the MultiSelect component.

#### PR Summary
This pull request improves the MultiSelect component by preventing event propagation in the dropdown and enhancing the handling of parameter updates. 
- `MultiSelect.razor`: Added `@onclick:stopPropagation="true"` to the dropdown list to improve user interaction.
- `MultiSelect.razor.cs`: Introduced a new `Methods` region and implemented the `OnParametersSetAsync` method to handle updates to the `Items` collection.
- `MultiSelect.razor.cs`: Added a closing `#endregion` for better code organization.
