### PR TITLE
Fixed a bug where the DisplayProperty has too much text and it ends up making the checkbox smaller. This led to a problem where you have a list of items and most of them had the checkbox with the same size, but some of them had a much smaller checkbox.

### DIFF
--- a/MultiSelectPackage/Components/MultiSelect.razor.css
+++ b/MultiSelectPackage/Components/MultiSelect.razor.css
@@ -76,6 +76,9 @@
 .dropdown-item {
 	padding: 8px;
 	cursor: pointer;
+	display: flex;
+	align-items: center;
+	gap: 8px; /* Adds space between checkbox and text */
 }
 
 	.dropdown-item:hover {
@@ -99,6 +102,7 @@
 /* Checkbox and label */
 .dropdown-checkbox {
 	margin-right: 8px;
+	flex-shrink: 0; /* Prevents checkbox from shrinking */
 }
 
 .dropdown-label {


### PR DESCRIPTION
Fixed a bug where the DisplayProperty has too much text and it ends up making the checkbox smaller. This led to a problem where you have a list of items and most of them had the checkbox with the same size, but some of them had a much smaller checkbox.

Enhance dropdown item styling with flexbox layout

Updated `.dropdown-item` to use flexbox for improved alignment and spacing. Added `flex-shrink: 0` to `.dropdown-checkbox` to prevent size reduction during resizing.