### PR TITLE
Change project SDK to Microsoft.NET.Sdk.Web

### DIFF
--- a/MultiSelectPackage/MultiSelectPackage.csproj
+++ b/MultiSelectPackage/MultiSelectPackage.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>


### PR DESCRIPTION
Change project SDK to Microsoft.NET.Sdk.Web

Updated `MultiSelectPackage.csproj` to use the Web SDK, indicating the project is now a web application. Target frameworks remain `net9.0` and `net8.0`, with nullable reference types and implicit usings enabled.