### PR TITLE
Set project output type to Library

### DIFF
--- a/MultiSelectPackage/MultiSelectPackage.csproj
+++ b/MultiSelectPackage/MultiSelectPackage.csproj
@@ -19,6 +19,7 @@
 		<RepositoryUrl>https://github.com/antglesic/MultiSelectPackage</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>Blazor, multiselect, dropdown, combobox</PackageTags>
+		<OutputType>Library</OutputType>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Set project output type to Library

Added `<OutputType>Library</OutputType>` to the project file to specify that the output type of the project is a library.