### PR TITLE
Fixing and issue with the Id's of the checkbox inputs where it only used the IdentifierProperty for it's Id.

### DIFF
--- a/MultiSelectPackage/Components/MultiSelect.razor
+++ b/MultiSelectPackage/Components/MultiSelect.razor
@@ -38,12 +38,12 @@
 			{
 				<div class="dropdown-item">
 					<input type="checkbox"
-						   id="@GetPropertyValue(item, IdentifierProperty)"
+						   id="@($"{ComponentId}_{GetPropertyValue(item, IdentifierProperty)}")"
 						   value="@GetPropertyValue(item, IdentifierProperty)"
 						   checked="@IsSelected(item)"
 						   @onchange="() => OnValueChanged(item)"
 						   class="dropdown-checkbox" />
-					<label for="@GetPropertyValue(item, IdentifierProperty)" class="dropdown-label">
+					<label for="@($"{ComponentId}_{GetPropertyValue(item, IdentifierProperty)}")" class="dropdown-label">
 						@GetPropertyValue(item, DisplayProperty)
 					</label>
 				</div>

--- a/MultiSelectPackage/Components/MultiSelect.razor.cs
+++ b/MultiSelectPackage/Components/MultiSelect.razor.cs
@@ -33,6 +33,9 @@ namespace MultiSelectPackage.Components
 		[Parameter]
 		public string CustomStyle { get; set; } = string.Empty;
 
+		[Parameter]
+		public string ComponentId { get; set; } = Guid.NewGuid().ToString("N");
+
 		#endregion
 
 		#region Properties

--- a/MultiSelectPackage/MultiSelectPackage.csproj
+++ b/MultiSelectPackage/MultiSelectPackage.csproj
@@ -12,7 +12,7 @@
 		<PackageId>MultiSelectPackage</PackageId>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-		<Version>1.0.1</Version>
+		<Version>1.0.2</Version>
 		<Authors>Antonio Glešić</Authors>
 		<Company></Company>
 		<Description>My blazor multi selection dropdown component</Description>


### PR DESCRIPTION
Fixing and issue with the Id's of the checkbox inputs where it only used the IdentifierProperty for it's Id.
This issue was found by using the MultiSelect component multiple times on the same page with different data, but with the same IdentifierProperty (for example int Id) so when something is selected in the second multiselect, it would result in return data from the first multiselect with the corresponding identifier.

Update MultiSelect component for unique identification

- Modified checkbox `id` attributes in `MultiSelect.razor` to include `ComponentId` for uniqueness.
- Added `ComponentId` parameter in `MultiSelect.razor.cs`, initialized with a new GUID.
- Incremented version number from `1.0.1` to `1.0.2` in `MultiSelectPackage.csproj`.