### PR TITLE
Switching sdk from web to razor so it works on webassembly aswell

### DIFF
--- a/MultiSelectPackage/MultiSelectPackage.csproj
+++ b/MultiSelectPackage/MultiSelectPackage.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
 		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
@@ -12,7 +12,7 @@
 		<PackageId>MultiSelectPackage</PackageId>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 		<Authors>Antonio Glešić</Authors>
 		<Company></Company>
 		<Description>My blazor multi selection dropdown component</Description>


### PR DESCRIPTION
Switching sdk from web to razor so it works on webassembly aswell

Update project SDK and version number

Changed SDK from Microsoft.NET.Sdk.Web to Microsoft.NET.Sdk.Razor for better Razor component support. Incremented version from 1.0.2 to 1.0.3 to reflect new features or fixes.