### PR TITLE
Fixing the multiselect component for the case when you need to open a page with data and preselected data for the multiselect component so you provide it to the component as a parameter

### DIFF
--- a/MultiSelectPackage/Components/MultiSelect.razor.cs
+++ b/MultiSelectPackage/Components/MultiSelect.razor.cs
@@ -10,6 +10,9 @@ namespace MultiSelectPackage.Components
 		public required IEnumerable<T> Items { get; set; }
 
 		[Parameter]
+		public IEnumerable<T>? SelectedItems { get; set; }
+
+		[Parameter]
 		public required string IdentifierProperty { get; set; }
 
 		[Parameter]
@@ -42,7 +45,7 @@ namespace MultiSelectPackage.Components
 
 		private List<T> ItemList = new List<T>();
 		private List<T> FilteredItemList = new List<T>();
-		private List<object> SelectedValues = new List<object>();
+		private List<T> SelectedValues = new List<T>();
 		private bool isDropdownOpen = false;
 
 		#endregion
@@ -59,6 +62,13 @@ namespace MultiSelectPackage.Components
 				{
 					ItemList = Items.ToList();      // Initialize ItemList with the provided items
 					FilteredItemList = ItemList;    // Initialize the filtered list with all items
+
+					// Check if SelectedItems is not null and has records
+					if (SelectedItems != null && SelectedItems.Any())
+					{
+						// If SelectedItems is not equal to the current SelectedValues, update SelectedValues so that the UI reflects the changes
+						SelectedValues = SelectedItems.ToList();
+					}
 				}
 			}
 
@@ -158,7 +168,7 @@ namespace MultiSelectPackage.Components
 				// Trigger the ValuesChanged callback
 				if (ValuesChanged.HasDelegate)
 				{
-					await ValuesChanged.InvokeAsync(SelectedValues.Cast<T>().ToList());
+					await ValuesChanged.InvokeAsync(SelectedValues);
 				}
 
 				// Re-render the component
@@ -227,7 +237,7 @@ namespace MultiSelectPackage.Components
 				{
 					SelectedValues.Remove(itemToRemove);
 					retval = true;
-					await ValuesChanged.InvokeAsync(SelectedValues.Cast<T>().ToList());
+					await ValuesChanged.InvokeAsync(SelectedValues);
 					await InvokeAsync(StateHasChanged);
 				}
 			}

--- a/MultiSelectPackage/MultiSelectPackage.csproj
+++ b/MultiSelectPackage/MultiSelectPackage.csproj
@@ -12,7 +12,7 @@
 		<PackageId>MultiSelectPackage</PackageId>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-		<Version>1.0.3</Version>
+		<Version>1.0.4</Version>
 		<Authors>Antonio Glešić</Authors>
 		<Company></Company>
 		<Description>My blazor multi selection dropdown component</Description>


### PR DESCRIPTION
Fixing the multiselect component for the case when you need to open a page with data and preselected data for the multiselect component so you provide it to the component as a parameter

Add SelectedItems parameter and update version to 1.0.4

- Introduced a new optional `SelectedItems` parameter for user-selected items.
- Changed `SelectedValues` type from `List<object>` to `List<T>`.
- Updated initialization logic for `SelectedValues` based on `SelectedItems`.
- Simplified `ValuesChanged` callback invocation to use `SelectedValues` directly.
- Bumped project version from `1.0.3` to `1.0.4`.